### PR TITLE
Removed getCurrentSubId()

### DIFF
--- a/contracts/interfaces/VRFCoordinatorInterface.sol
+++ b/contracts/interfaces/VRFCoordinatorInterface.sol
@@ -123,6 +123,4 @@ interface VRFCoordinatorInterface {
    */
   function pendingRequestExists(uint64 subId) external view returns (bool);
 
-  function getCurrentSubId() external returns (uint64 subId);
-
 }


### PR DESCRIPTION
Removed method getCurrentSubId() from VRFCoordinatorInterface.sol, this method is no long needed.